### PR TITLE
Add attention_text and create_option_cycle

### DIFF
--- a/ui_funtions/attention_text.md
+++ b/ui_funtions/attention_text.md
@@ -1,0 +1,48 @@
+## attention_text(args[^1])
+Displays a pop-up text at a specified anchor and offset. The behavior of the text backdrop depends on the anchor setting: using `major` produces effects similar to scoring with cards, while `cover` creates effects reminiscent of earning money.
+Whenever both `major` and `cover` are used, `cover` takes precedence 
+
+### Example usage
+`attention_text` using `cover`:
+```lua
+attention_text({
+    text = "x2",
+    scale = 0.8, 
+    hold = 1,
+    cover = G.hand_text_area.mult.parent,
+    cover_colour = mix_colours(G.C.MULT, col, 0.1),
+    emboss = 0.05,
+    align = 'cm',
+    cover_align = 'cl'
+})
+```
+
+`attention_text` using `major`:
+```lua
+attention_text({
+    scale = 0.9, 
+    text = "lorem ipsum", 
+    hold = 0.9, 
+    align = 'tm',
+    major = G.play, 
+    offset = {x = 0, y = -1}
+})
+```
+
+[^1]:
+    | key  | type | description |
+    | ------------- | ------------- | ------------- |
+    | text | string | The text to display on screen. |
+    | scale | number | The scale of the text to display, defaults to `1`. |
+    | colour | table | The colour of the displayed text, defaults to `G.C.WHITE`. |
+    | hold | number | The time the text should be displayed on screen before going away, defaults to `0`. |
+    | align | string | The alignment the text should follow. |
+    | offset | table | The local offset to the primary position (dictated by either `cover` or `major`) of the text, defaults to `{x = 0, y =0}`. |
+    | major | table | The anchoring point that will be used for the global transformation of the text. |
+    | cover | (node) table | The UI element that will be used for the global transformation of the text. |
+    | emboss | number | The size of the embossing of the cover box, giving it the illusion of being 3 dimensional. defaults to `0`. |
+    | cover_colour | table | The colour of the box that will be covering the `cover` element, defaults to `G.C.RED`. If no `cover` argument is set in the table, this argument does not have any effect. |
+    | cover_padding | number | The padding space around the text inside of the cover box, defaults to `0`. |
+    | cover_align | string | The alignment the cover should follow. |
+    | backdrop_colour | table | The colour of the backdrop box particle. |
+    

--- a/ui_funtions/create_option_cycle.md
+++ b/ui_funtions/create_option_cycle.md
@@ -1,0 +1,55 @@
+# create_option_cycle(args[^1])
+Creates a selection box that can be cycled through to select a specific option, this element is similar to the one used to select the game's speed.
+
+### Example usage
+```lua
+SMODS.current_mod.config_tab = function()
+    return {n = G.UIT.ROOT, config = {
+        ...
+    }, nodes = {
+        create_option_cycle({
+            options = {
+                "foo",
+                "bar"
+            },
+            current_option = SMODS.current_mod.config.my_config_option,
+            opt_callback = "my_option_cycle"
+        })
+    }}
+end
+
+
+function G.FUNCS.my_option_cycle(e)
+    ...
+end
+```
+[^1]: args table
+    | key  | type | description |
+    | ------------- | ------------- | ------------- |
+    | label | string | The text to display in the main cycle box |
+    | id | string | (optional) The identifier used to search for the specific node. |
+    | colour  | table  | The colour of the cycle box and buttons, defaults to `G.C.RED` (#FE5F55). |
+    | options | table | The options to display in the options cycle, defaults to `{ 'Option 1', 'Option 2' }`. |
+    | current_option | int | The index of the currently selected option, defaults to `1`.  |
+    | no_pips | bool | Determines if the pips are displayed on the option cycle, provided there is enough space. If left out, it will attempt to put pips in the option cycle. |
+    | opt_callback | string | The name of the function in `G.FUNCS` to be called, it will pass along a table of callback arguments[^2]. If left empty, no function will be called. |
+    | scale | number | The scale of the option cycle, defaults to `1`. |
+    | ref_table | table | A reference to a table to retrieve data from at a undetermined point in time. |
+    | ref_value | string | The name of the key in the `ref_table`. |
+    | w | number | Determines the minimum width of of the main cycle element (before scaling), defaults to `2.5`. |
+    | h | number | Determines the minimum height of of the main cycle element (before scaling), defaults to `0.8`. |
+    | text_scale | number | Determines how big the text will be scaled, defaults to `0.5`. |
+    | focus_args | table | A table containing hints on how passing around focus should be handled. |
+    | info | table | The lines of text to display under the option cycle. |
+    | mid| (node) table | Overrides the middle section of the options cycle and replaces it with a custom UI node. If left empty, the default cycle box will be used instead. |
+    | cycle_shoulders | bool | ?  (suggests toggling gamepad behaviour, however precise effect has not been figured out). |
+    | on_demand_tooltip | table | Adds a tooltip when the main cycle boc is hovered over. See `tooltip` for structure information. |
+
+[^2]: callback argument table
+    | key  | type | description |
+    | ------------- | ------------- | ------------- |
+    | from_val | string | The value of the previously selected option. |
+    | to_val | string | The value of the selected option. |
+    | from_key | int | The index of the previously selected option. |
+    | to_key | int | The index of the selected option. |
+    | cycle_config | table | The reference table containing the node information of the option cycle that invoked the callback. |


### PR DESCRIPTION
this PR aims to resolve https://github.com/Steamodded/Wiki/issues/81
supersedes: https://github.com/Steamodded/smods/pull/359

This PR aims to document the following UI related functions:
- [x] attention_text
- [x] create_option_cycle
- [ ] create_slider
- [ ] create_tabs
- [ ] create_text_input
- [ ] create_toggle
- [ ] SMODS.GUI.createOptionSelector
- [ ] UIBox_button
- [ ] simple_text_container