### PR TITLE
Fix and clarify details of Text Styling page

### DIFF
--- a/Text-Styling.md
+++ b/Text-Styling.md
@@ -292,7 +292,7 @@ This modifier uniquely strips all whitespace from the styled text, so text like 
    
    ```lua
    vars = {
-     colours = { HEX("#FF00FF") }
+     colours = { HEX("FF00FF") }
    }
    ```
   </td>
@@ -365,7 +365,7 @@ Unlike the similar [Defined background modifier `{X:}`](#defined-background-colo
    
    ```lua
    vars = {
-     colours = { HEX("#00FF00") }
+     colours = { HEX("00FF00") }
    }
    ```
   </td>

--- a/Text-Styling.md
+++ b/Text-Styling.md
@@ -810,7 +810,7 @@ Some style codes can be combined within one set of curly braces, like `{X:mult,C
    <code><b>inactive</code>
   </td>
   <td>
-   <code>G.C.INACTIVE</code>
+   <code>G.C.UI.TEXT_INACTIVE</code>
   </td>
   <td align="center">
    <img src="Assets/Text-Styling/example_Must_have_room.svg" height=24 alt="(Must have room)">
@@ -1011,7 +1011,7 @@ Some style codes can be combined within one set of curly braces, like `{X:mult,C
    <code><b>legendary</code>
   </td>
   <td>
-   <code>G.C.RARITY[4]</code> or <br> <code>G.C.RARITY.Legendary</code>
+   <code>G.C.RARITY[4]</code> (vanilla)<br> <code>G.C.RARITY.Legendary</code> (SMODS)
   </td>
   <td align="center">
    <picture>

--- a/Text-Styling.md
+++ b/Text-Styling.md
@@ -292,7 +292,7 @@ This modifier uniquely strips all whitespace from the styled text, so text like 
    
    ```lua
    vars = {
-     colours = { HEX("FF00FF") }
+     colours = { HEX('FF00FF') }
    }
    ```
   </td>
@@ -312,10 +312,10 @@ This modifier uniquely strips all whitespace from the styled text, so text like 
    
    ```lua
    vars = {
-     "Spade",
-     "Heart",
-     "Club",
-     "Diamond",
+     'Spade',
+     'Heart',
+     'Club',
+     'Diamond',
      colours = { 
        G.C.SUITS.Spades,
        G.C.SUITS.Hearts,
@@ -365,7 +365,7 @@ Unlike the similar [Defined background modifier `{X:}`](#defined-background-colo
    
    ```lua
    vars = {
-     colours = { HEX("00FF00") }
+     colours = { HEX('00FF00') }
    }
    ```
   </td>
@@ -411,8 +411,8 @@ Unlike the similar [Defined background modifier `{X:}`](#defined-background-colo
    
    ```lua
    vars = {
-     "Spa",
-     "rts",
+     'Spa',
+     'rts',
      colours = { 
        G.C.SUITS.Spades,
        G.C.SUITS.Hearts,

--- a/Text-Styling.md
+++ b/Text-Styling.md
@@ -430,10 +430,11 @@ Unlike the similar [Defined background modifier `{X:}`](#defined-background-colo
 
 
 ## Text motion modifier `{E:}`
-`{E:1}` applies a floating animation to each letter in the text.
+`{E:1}` applies a pop-in effect when the text is first displayed, and a floating animation to each letter in the text.
 
 `{E:2}` applies a bumping animation to each letter in sequence.
 
+`{E:}` is incompatible with background modifiers `{X:}` and `{B:}`. If background modifiers are set, `{E:1}` will only show a pop-in effect with no motion, and `{E:2}` will be ignored.
 
 ### Examples
 
@@ -554,6 +555,8 @@ Some style codes can be combined within one set of curly braces, like `{X:mult,C
 - `{T:}` and `{s:}` are compatible with all other modifiers.
 
 - Background modifiers `{X:}` or `{B:}` can be used in conjunction with text colour modifiers `{C:}` or `{V:}`.
+
+- Text motion modifier `{E:}` is incompatible with background modifiers `{X:}` and `{B:}` - if background modifiers are set, `{E:1}` will only show a pop-in effect with no motion, and `{E:2}` will be ignored.
 
 - `{C:}` and `{V:}` are exclusive - if both are used, `{C:}` will be ignored.
 


### PR DESCRIPTION
A small set of fixes to the Text Styling page:
- Fix value of `LOC_COLOURS` table entry with key `inactive` (from `G.C.INACTIVE` to `G.C.UI.TEXT_INACTIVE`)
- Clarify `G.C.RARITY` difference between vanilla and Steamodded in `LOC_COLOURS` table
- Remove mistaken `#` symbols in strings passed to `HEX` function calls
- Replace double quotes with single quotes to conform to SMODS Wiki convention
- Clarify incompatibilities between `{E:}` and `{X:}`/`{B:}`