### PR TITLE
Add some currently undocumented contexts in Calculate-Functions.md

### DIFF
--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -268,7 +268,21 @@ if context.after and context.cardarea == G.play then
 ```
 ---
 ### Other Contexts
-This context is used for trigger effects on playing a hand debuffed by the blind. 
+This context is used for debuffing a hand. 
+```lua
+if context.debuff_hand then
+{
+	cardarea = G.jokers, -- G.play, G.hand, (G.deck and G.discard optionally enabled)
+	full_hand = G.play.cards,
+	scoring_hand = scoring_hand,
+	poker_hands = poker_hands,
+	scoring_name = text,
+	check = check, -- This is true when called before a hand is played
+	debuff_hand = true
+}
+```
+---
+This context is used for effects when playing a hand debuffed by the blind. 
 ```lua
 if context.debuffed_hand and context.cardarea == G.play then
 {
@@ -277,7 +291,34 @@ if context.debuffed_hand and context.cardarea == G.play then
 	scoring_hand = scoring_hand,
 	scoring_name = text,
 	poker_hands = poker_hands,
-	debuffed_hand = true,
+	debuffed_hand = true
+}
+```
+---
+This context is used for marking cards to be in the scoring hand. 
+```lua
+if context.modify_scoring_hand then
+{
+	cardarea = G.jokers -- G.play, G.hand, (G.deck and G.discard optionally enabled)
+	other_card = card, -- The card to be added or removed from scoring
+	full_hand = G.play.cards,
+	scoring_hand = scoring_hand,
+	modify_scoring_hand = true
+}
+```
+> [!TIP]
+> Return `{ add_to_hand = true }` or `{ remove_from_hand = true }` to add or remove the card from the scoring hand.
+---
+This context is used for effects at the same time a hand would be modified by a blind.
+```lua
+if context.modify_hand then
+{
+	cardarea = G.jokers, -- G.play, G.hand, (G.deck and G.discard optionally enabled)
+	full_hand = G.play.cards,
+	scoring_hand = scoring_hand,
+	scoring_name = text,
+	poker_hands = poker_hands,
+	modify_hand = true
 }
 ```
 ---
@@ -419,7 +460,7 @@ if context.drawing_cards then
 }
 ```
 > [!TIP]
-> Returning `{ cards_to_draw = num }` changes the number of drawn cards to `num`.
+> Return `{ cards_to_draw = num }` to change the number of drawn cards to `num`.
 ---
 This context is used for effects after drawing the first hand of a blind. 
 ```lua

--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -281,6 +281,8 @@ if context.debuff_hand then
 	debuff_hand = true
 }
 ```
+> [!TIP]
+> You can return `{ debuff = true }` or `{ prevent_debuff = true }`
 ---
 This context is used for effects when playing a hand debuffed by the blind. 
 ```lua
@@ -476,7 +478,7 @@ This context is used for effects after drawing a hand when facing a blind.
 if context.hand_drawn then
 {
 	cardarea = G.jokers, -- G.hand, (G.deck and G.discard optionally enabled)
-	hand_drawn = true,
+	hand_drawn = drawn_cards, --The cards that have been drawn
 }
 ```
 ---
@@ -485,7 +487,7 @@ This context is used for effects after drawing a hand when not facing a blind.
 if context.other_drawn then
 {
 	cardarea = G.jokers, -- G.hand, (G.deck and G.discard optionally enabled)
-	other_drawn = true,
+	other_drawn = drawn_cards,
 }
 ```
 ---

--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -282,7 +282,7 @@ if context.debuff_hand then
 }
 ```
 > [!TIP]
-> You can return `{ debuff = true }` or `{ prevent_debuff = true }`
+> You can return `{ debuff = true }` to debuff the hand or `{ prevent_debuff = true }` to stop the hand from being debuffed
 ---
 This context is used for effects when playing a hand debuffed by the blind. 
 ```lua

--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -307,7 +307,7 @@ if context.modify_scoring_hand then
 }
 ```
 > [!TIP]
-> Return `{ add_to_hand = true }` or `{ remove_from_hand = true }` to add or remove the card from the scoring hand.
+> Return `{ add_to_hand = true }` or `{ remove_from_hand = true }` to add or remove `context.other_card` from the scoring hand.
 ---
 This context is used for effects at the same time a hand would be modified by a blind.
 ```lua

--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -409,6 +409,18 @@ if context.ending_shop then
 }
 ```
 ---
+This context is used for effects when drawing cards. 
+```lua
+if context.drawing_cards then
+{
+	cardarea = G.jokers, -- G.hand, (G.deck and G.discard optionally enabled)
+	drawing_cards = true,
+	amount = hand_space -- The amount of cards that will be drawn
+}
+```
+> [!TIP]
+> Returning `{ cards_to_draw = num }` changes the number of drawn cards to `num`.
+---
 This context is used for effects after drawing the first hand of a blind. 
 ```lua
 if context.first_hand_drawn then
@@ -418,7 +430,7 @@ if context.first_hand_drawn then
 }
 ```
 ---
-This context is used for effects after drawing a hand. 
+This context is used for effects after drawing a hand when facing a blind. 
 ```lua
 if context.hand_drawn then
 {
@@ -427,7 +439,16 @@ if context.hand_drawn then
 }
 ```
 ---
-This context is used for effects after using a consumable 
+This context is used for effects after drawing a hand when not facing a blind. 
+```lua
+if context.other_drawn then
+{
+	cardarea = G.jokers, -- G.hand, (G.deck and G.discard optionally enabled)
+	other_drawn = true,
+}
+```
+---
+This context is used for effects after using a consumable. 
 ```lua
 if context.using_consumeable then
 {

--- a/SMODS.Stake.md
+++ b/SMODS.Stake.md
@@ -9,7 +9,7 @@
 > [!IMPORTANT]
 > An extra line that lists applied stakes is appended at the end of the description only when `loc_txt` is used. If you are using localization files, you should add this yourself.
 - **Optional parameters** *(defaults)*:
-    - `atlas = 'chips', pos = { x = 0, y = 0 }` [(reference)](https://github.com/Steamodded/smods/wiki/SMODS.Atlas#applying-textures-to-cards
+    - `atlas = 'chips', pos = { x = 0, y = 0 }` [(reference)](https://github.com/Steamodded/smods/wiki/SMODS.Atlas#applying-textures-to-cards)
     - `sticker_atlas, sticker_pos`: The atlas and position to use for this stake's win sticker.
     - `unlocked = false, prefix_config, dependencies` [(reference)](https://github.com/Steamodded/smods/wiki/API-Documentation#common-parameters)
         - If `unlocked` is set to `false`, the stake is unlocked by first winning a run on each of the `applied_stakes`.


### PR DESCRIPTION
### Adds documentation for:
- context.debuff_hand
- context.modify_hand
- context.modify_scoring_hand
- context.drawing_cards
- context.other_drawn

Slightly changes the description for context.hand_drawn

Fixes missing bracket on the atlas reference link in SMODS.Stake.md