### PR TITLE
add text_colour to ConsumableType docs

### DIFF
--- a/SMODS.ObjectType.md
+++ b/SMODS.ObjectType.md
@@ -42,6 +42,7 @@ This is a subclass of `SMODS.ObjectType`. All values and functions tied to `SMOD
 	- `collection_rows = { 6, 6 }`: Customize the collection for this card type. Each value indicates a row with the specified amount of cards.
 	- `shop_rate`: Setting a numerical value for `shop_rate` enables cards of this type to appear in the shop at the specified rate.
 		- This sets a default rate, which can be modified by accessing `G.GAME[key:lower() .. '_rate']` during a run.
+	- `text_colour`: Set a custom text color used on the card type's badge. This can take any HEX color, and saves it as `G.C.UI[key]`.
 
 ## API methods
 - `ObjectType.inject_card(self, center)`


### PR DESCRIPTION
i forgot to do this when it was initially implemented. woops