### PR TITLE
Changes to pre-scoring contexts

### DIFF
--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -818,7 +818,7 @@ if context.debuff_hand then
 ```lua
 context.full_hand, context.scoring_hand, context.scoring_name, context.poker_hands
 context.debuff_hand -- flag to identify this context, always TRUE
-context.check -- TRUE when the player is selecting cards in hand as opposed to playing them
+context.check -- true while the hand is being selected, and false when the hand is played
 ```
 
   ---


### PR DESCRIPTION
Makes the following changes:

* fixes the name for `replace_scoring_name` in context `evaluate_poker_hand`
* Adds missing `context.debuff_hand` (Fixes #62)
* Reorders these pre-scoring context to be in calculation order (press_play (if hand is played) > evaluate_poker_hand > modify_scoring_hand > debuff_hand > modify_hand > ...). I didn't check the order for anything after that, maybe these could have their own section too.