### PR TITLE
`always_scores` and `never_scores`

### DIFF
--- a/SMODS.Center/SMODS.Edition.md
+++ b/SMODS.Center/SMODS.Edition.md
@@ -35,6 +35,8 @@
 	- `sound = { sound = "foil1", per = 1.2, vol = 0.4 }`: Used to set a custom sound when the edition is applied.
 	- `disable_shadow`: Disables shadow drawn under the card.
 	- `disable_base_shader = false`: Whether the base shader should be applied (`booster` for Booster packs and Spectral cards, `voucher` for Vouchers and Invisible Joker, `dissolve` otherwise). Enable this if your shader modifies card transparency or shape in any way. Example:<br/>![image](https://github.com/user-attachments/assets/c7b32385-e486-40c2-9a83-c8a09a67185c)
+	- `always_scores`: If `true`, editioned card always counts in scoring.
+    - `never_scores`: If `true`, editioned card never counts in scoring (supersedes `always_scores`).
 
 ## API methods
 - `loc_vars` [(reference)](https://github.com/Steamodded/smods/wiki/Localization#Localization-functions)

--- a/SMODS.Center/SMODS.Enhancement.md
+++ b/SMODS.Center/SMODS.Enhancement.md
@@ -38,6 +38,7 @@
     - `any_suit`: If `true`, enhanced card counts as any suit.
     - `shatters`: If `true`, enhanced card breaks on destruction like a Glass Card.
     - `always_scores`: If `true`, enhanced card always counts in scoring.
+    - `never_scores`: If `true`, enhanced card never counts in scoring (supersedes `always_scores`).
 	- `weight`: The weighting of the enhancement, follows same rules as other weighted objects *(default weight is 5)*.
 
 ## API methods

--- a/SMODS.Seal.md
+++ b/SMODS.Seal.md
@@ -13,6 +13,8 @@
         - `sound`: The key of the sound to play.
         - `per`: The pitch at which the sound should be played.
         - `vol`: The volume at which the sound should be played.
+    - `always_scores`: If `true`, editioned card always counts in scoring.
+    - `never_scores`: If `true`, editioned card never counts in scoring (supersedes `always_scores`).
 
 ## API methods
 - `calculate(self, card, context)` [(reference)](https://github.com/Steamodded/smods/wiki/Calculate-Functions)

--- a/SMODS.Sticker.md
+++ b/SMODS.Sticker.md
@@ -18,6 +18,8 @@
 	```
 	- `rate = 0.3`: Chance of the sticker applying on an eligible card
 	- `needs_enable_flag`: If set to `true`, this sticker requires `G.GAME.modifiers['enable_'..self.key]` to be `true` before it can be applied.
+	- `always_scores`: If `true`, editioned card always counts in scoring.
+    - `never_scores`: If `true`, editioned card never counts in scoring (supersedes `always_scores`).
 
 ## API methods
 - `calculate(self, card, context)` [(reference)](https://github.com/Steamodded/smods/wiki/Calculate-Functions)


### PR DESCRIPTION
Adds `always_scores` and `never_scores` docs to Enhancements. Editions, Seals and Stickers