### PR TITLE
change description of pseudorandom_result context

### DIFF
--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -1334,7 +1334,7 @@ context.from_roll -- internal value used to only trigger certain return values w
 
 ---
 #### context.pseudorandom_result
-This context should be used for setting either the numerator or the denominator.
+This context is used _after_ a probability is checked. It receives the final numerators and denominators that were used, as well as whether the chance succeeded.
 
 ```lua
 if context.pseudorandom_result then


### PR DESCRIPTION
was scrolling through the wiki while exceptionally bored last night and noticed that this context description wasn't particularly accurate. this context isn't used for changing any probabilities, it's just used to know when a probability has been checked