### PR TITLE
Fix context.modify_hand tip using mod_mult instead of mod_chips

### DIFF
--- a/Calculate-Functions.md
+++ b/Calculate-Functions.md
@@ -896,7 +896,7 @@ context.poker_hands -- the list of poker hands contained within the selected car
 ```
 
 >[!TIP]
->You can modify chips and mult by doing `hand_chips = mod_mult(hand_chips + value)` and `mult = mod_mult(mult + value)` or any scoring parameter, including chips and mult, by calling `SMODS.Scoring_Parameters.key:modify(value)`.
+>You can modify chips and mult by doing `hand_chips = mod_chips(hand_chips + value)` and `mult = mod_mult(mult + value)` or any scoring parameter, including chips and mult, by calling `SMODS.Scoring_Parameters.key:modify(value)`.
 
 ---
 #### context.debuff_card


### PR DESCRIPTION
The tip for `context.modify_hand` explaining how to change base Chips and Mult says to use `mod_mult` for `hand_chips`, instead of using `mod_chips`.

(this is literally my first ever github pr hopefully i did this right and nothing implodes)